### PR TITLE
Use caching to increase build speed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,13 @@ FROM golang:alpine
 RUN mkdir /src
 ADD . /src/
 WORKDIR /src
-ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 
 # Build the application
 
 RUN --mount=target=. \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    go build -o /app/run .
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /app/run .
 
 # Add the execution user
 RUN adduser -S -D -H -h /app execuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,25 @@
 FROM golang:alpine
 
 # Create application directory
-RUN mkdir /app
-ADD . /app/
-WORKDIR /app
+RUN mkdir /src
+ADD . /src/
+WORKDIR /src
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 
 # Build the application
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go mod download
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o run .
+COPY go.* .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+    --mount=type=cache,target=/go/pkg/mod \
+    go mod graph | awk '{if ($1 !~ "@") print $2}' | xargs -r go get
+
+RUN --mount=target=. \
+    --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go build -o /app/run .
 
 # Add the execution user
 RUN adduser -S -D -H -h /app execuser
 USER execuser
 
 # Run the application
-CMD ["./run"]
+CMD ["/app/run"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,6 @@ ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 
 # Build the application
 COPY go.* .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
-    --mount=type=cache,target=/go/pkg/mod \
-    go mod graph | awk '{if ($1 !~ "@") print $2}' | xargs -r go get
-
 RUN --mount=target=. \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /src
 ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
 
 # Build the application
-COPY go.* .
+
 RUN --mount=target=. \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \


### PR DESCRIPTION
This isn't the cleanest way to do it but it works. You don't have to download all dependencies every time you rebuild the image, and the image size seems to be reduced by 60% as well.

My rebuild process only takes 25 seconds instead of 150 seconds.